### PR TITLE
alter ioutil.ReadAll to io.copy

### DIFF
--- a/api/web/route_test.go
+++ b/api/web/route_test.go
@@ -13,8 +13,9 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -95,10 +96,11 @@ func Test_RouteHandler(t *testing.T) {
 			handler(w, req)
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			var b bytes.Buffer
+			io.Copy(&b, resp.Body)
 
 			var successResponse http2.OcpAgentResponse
-			_ = json.Unmarshal(body, &successResponse)
+			_ = json.Unmarshal(b.Bytes(), &successResponse)
 
 			So(resp.StatusCode, ShouldEqual, tt.want.statusCode)
 			So(successResponse.Successful, ShouldEqual, tt.want.successful)

--- a/api/web/server_test.go
+++ b/api/web/server_test.go
@@ -13,8 +13,9 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,10 +38,11 @@ func Test_NewServer(t *testing.T) {
 		handler(w, req)
 
 		resp := w.Result()
-		body, _ := ioutil.ReadAll(resp.Body)
+		var b bytes.Buffer
+		io.Copy(&b, resp.Body)
 
 		var successResponse http2.OcpAgentResponse
-		_ = json.Unmarshal(body, &successResponse)
+		_ = json.Unmarshal(b.Bytes(), &successResponse)
 
 		So(resp.StatusCode, ShouldEqual, http.StatusOK)
 		So(successResponse.Status, ShouldEqual, http.StatusOK)

--- a/lib/command/task_store.go
+++ b/lib/command/task_store.go
@@ -14,10 +14,10 @@ package command
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,14 +198,15 @@ func (fts *FileTaskStore) loadFromReader(f io.Reader) (StoredStatus, error) {
 	}
 
 	if header.ResponseType != TypeStructured {
-		body, err := ioutil.ReadAll(reader)
+		var b bytes.Buffer
+		_, err = io.Copy(&b, reader)
 		if err != nil {
 			return StoredStatus{}, err
 		}
 		if header.ResponseType == TypeBinary {
-			header.Result = body
+			header.Result = b.Bytes()
 		} else if header.ResponseType == TypeText {
-			header.Result = string(body)
+			header.Result = b.String()
 		}
 	}
 	return header, nil

--- a/lib/file/file.go
+++ b/lib/file/file.go
@@ -128,7 +128,7 @@ func (f FileImpl) Sha256Checksum(path string) (string, error) {
 		return "", errors.Errorf("failed to compute sha1 for %s, cannot open file: %s", path, err)
 	}
 	defer file.Close()
-	
+
 	hasher := sha256.New()
 	_, err = io.Copy(hasher, file)
 	if err != nil {

--- a/lib/http/client.go
+++ b/lib/http/client.go
@@ -16,7 +16,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -76,13 +76,14 @@ func (ac *ApiClient) Call(api string, param interface{}, retPtr interface{}) err
 	envelop := OcpAgentResponse{
 		Data: retPtr,
 	}
-	bs, err := ioutil.ReadAll(resp.Body)
+	var b bytes.Buffer
+	_, err = io.Copy(&b, resp.Body)
 	if err != nil {
 		return ApiRequestFailedErr.NewError(api).WithCause(err)
 	}
-	cpResp := make([]byte, len(bs))
-	copy(cpResp, bs)
-	respReader := bytes.NewReader(bs)
+	cpResp := make([]byte, len(b.Bytes()))
+	copy(cpResp, b.Bytes())
+	respReader := bytes.NewReader(b.Bytes())
 
 	if resp.StatusCode != http.StatusOK {
 		err = json.NewDecoder(respReader).Decode(&envelop)

--- a/lib/http/http_command_test.go
+++ b/lib/http/http_command_test.go
@@ -16,7 +16,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -114,19 +114,20 @@ func TestNewFuncHandler(t *testing.T) {
 		t.Error(err)
 	}
 	handler.ServeHTTP(resp, req)
-	body, err := ioutil.ReadAll(resp.Body)
+	var b bytes.Buffer
+	_, err = io.Copy(&b, resp.Body)
 	if err != nil {
 		t.Error(err)
 	}
 	envelop := OcpAgentResponse{
 		Data: 0,
 	}
-	err = json.Unmarshal(body, &envelop)
+	err = json.Unmarshal(b.Bytes(), &envelop)
 	if err != nil {
 		t.Error(err)
 	}
 	if envelop.Data != 14 {
 		t.Error("bad value")
 	}
-	fmt.Println(string(body))
+	fmt.Println(b.String())
 }

--- a/lib/process/proc.go
+++ b/lib/process/proc.go
@@ -13,8 +13,8 @@
 package process
 
 import (
+	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -99,18 +99,20 @@ func (p *Proc) Start(params map[string]string) (err error) {
 	if stdout != nil {
 		stdoutChan = make(chan []byte, 1)
 		go func() {
-			b, _ := ioutil.ReadAll(stdout)
+			var b bytes.Buffer
+			io.Copy(&b, stdout)
 			_ = stdout.Close()
-			stdoutChan <- b
+			stdoutChan <- b.Bytes()
 			close(stdoutChan)
 		}()
 	}
 	if stderr != nil {
 		stderrChan = make(chan []byte, 1)
 		go func() {
-			b, _ := ioutil.ReadAll(stderr)
+			var b bytes.Buffer
+			io.Copy(&b, stdout)
 			_ = stderr.Close()
-			stderrChan <- b
+			stderrChan <- b.Bytes()
 			close(stderrChan)
 		}()
 	}

--- a/monitor/plugins/exporters/prometheus/metric_handler_test.go
+++ b/monitor/plugins/exporters/prometheus/metric_handler_test.go
@@ -13,8 +13,9 @@
 package prometheus
 
 import (
+	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -50,7 +51,8 @@ func TestPipelineGroupReader(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data := bytes.Buffer{}
+	_, err = io.Copy(&data, res.Body)
 	res.Body.Close()
 	assert.Nil(t, err)
 	assert.Equal(t, `# HELP test1_count monitor collected message
@@ -62,5 +64,5 @@ test2_count{t="2"} 2.2
 # HELP test3_count monitor collected message
 # TYPE test3_count counter
 test3_count{t="1"} 1.1
-`, string(data))
+`, data.String())
 }

--- a/monitor/plugins/inputs/log_tailer/log_tailer_recovery.go
+++ b/monitor/plugins/inputs/log_tailer/log_tailer_recovery.go
@@ -14,10 +14,10 @@ package log_tailer
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -157,18 +157,19 @@ func loadLastPosition(ctx context.Context, recoveryConf monagent.RecoveryConfig,
 
 func loadPositionFromReader(f io.Reader) (*RecoveryInfo, error) {
 	reader := bufio.NewReader(f)
-	body, err := ioutil.ReadAll(reader)
+	var b bytes.Buffer
+	_, err := io.Copy(&b, reader)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(body) == 0 {
+	if len(b.Bytes()) == 0 {
 		return nil, nil
 	}
 
 	recoveryInfo := &RecoveryInfo{}
 
-	err = json.Unmarshal(body, recoveryInfo)
+	err = json.Unmarshal(b.Bytes(), recoveryInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/monitor/plugins/outputs/pushhttp/http_sender.go
+++ b/monitor/plugins/outputs/pushhttp/http_sender.go
@@ -207,8 +207,9 @@ func (s *HttpSender) send(ctx context.Context, reader io.Reader) error {
 	}).Observe(float64(time.Now().Sub(startTime)) / float64(time.Millisecond))
 
 	if !s.acceptedResponseCodes[resp.StatusCode] {
-		body, _ := io.ReadAll(resp.Body)
-		return errors.Errorf("%s error code: %d, body: %s", s.address(), resp.StatusCode, body)
+		var b bytes.Buffer
+		io.Copy(&b, resp.Body)
+		return errors.Errorf("%s error code: %d, body: %s", s.address(), resp.StatusCode, b.Bytes())
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
ioutil.ReadAll can cause a panic when writing large files due to memory problems, instead of io.copy.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
